### PR TITLE
feat: warn when telegram env missing

### DIFF
--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -36,7 +36,11 @@ def _fmt_date(dt_str: str | None) -> str:
     try:
         return datetime.fromisoformat(dt_str.replace("Z", "+00:00")).strftime("%d.%m.%Y %H:%M")
     except Exception:
-        return datetime.now().strftime("%d.%m.%Y %H:%М")
+        # Fallback to current time if parsing fails.
+        # Use Latin 'M' in the minutes placeholder to avoid ValueError
+        # when strftime encounters the Cyrillic letter (which happened
+        # in the previous implementation).
+        return datetime.now().strftime("%d.%m.%Y %H:%M")
 
 def _shipping_title(order: dict) -> str:
     lines = order.get("shipping_lines") or []

--- a/test_order.py
+++ b/test_order.py
@@ -39,6 +39,16 @@ class OrderTester:
         self.webhook_url = f"{self.host}/webhooks/shopify/orders"
         self.secret = os.getenv("SHOPIFY_WEBHOOK_SECRET", "test_secret")
 
+    def check_telegram_env(self) -> None:
+        """Проверяет наличие переменных окружения для Telegram."""
+        missing = [
+            var for var in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_TARGET_CHAT_ID")
+            if not os.getenv(var)
+        ]
+        if missing:
+            print("\n⚠️ Не заданы переменные окружения: " + ", ".join(missing))
+            print("   Отправка PDF/VCF и сообщений в Telegram может не выполниться")
+
     def get_order_from_shopify(self, order_id: int) -> Optional[Dict[Any, Any]]:
         """Получает заказ из Shopify API."""
         print(f"📥 Получаем заказ #{order_id} из Shopify...")
@@ -215,6 +225,9 @@ class OrderTester:
         print("=" * 50)
         print(f"🧪 ТЕСТИРОВАНИЕ ЗАКАЗА #{order_id}")
         print("=" * 50)
+
+        # Проверяем, настроена ли отправка в Telegram
+        self.check_telegram_env()
 
         # 1. Получаем заказ из Shopify
         order_data = self.get_order_from_shopify(order_id)


### PR DESCRIPTION
## Summary
- warn if Telegram bot token or target chat id not set before testing orders

## Testing
- `python test_order.py 6417067999535 -f`
- `pytest -q` *(fails: fixture 'order_id' not found; phone formatting assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9831c28832aa25e6e9c89ececcf