### PR TITLE
Implement callback router and menu UI

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Tuple, Dict
+
+
+def route_callback(data: str) -> Tuple[str | None, Dict[str, object]]:
+    """Parse callback_data into action and params."""
+    parts = (data or "").split(":")
+    if not parts or parts[0] == "":
+        return None, {}
+
+    try:
+        if parts[0] == "order":
+            order_id = int(parts[1])
+            if len(parts) == 4 and parts[2] == "set":
+                return "order_set", {"order_id": order_id, "status": parts[3]}
+            if len(parts) == 3 and parts[2] == "view":
+                return "order_view", {"order_id": order_id}
+            if len(parts) == 4 and parts[2] == "resend" and parts[3] in {"pdf", "vcf"}:
+                return "order_resend", {"order_id": order_id, "format": parts[3]}
+        elif parts[0] == "orders" and len(parts) >= 4 and parts[1] == "list":
+            kind = parts[2]
+            if parts[3].startswith("offset="):
+                offset = int(parts[3].split("=", 1)[1])
+            else:
+                offset = 0
+            return "orders_list", {"kind": kind, "offset": offset}
+    except Exception:
+        return None, {}
+
+    return None, {}
+

--- a/app/services/menu_ui.py
+++ b/app/services/menu_ui.py
@@ -1,0 +1,42 @@
+from typing import Literal, List
+
+
+Button = dict
+
+
+def main_menu_buttons() -> List[List[Button]]:
+    """Главное меню"""
+    return [
+        [{"text": "Очікують", "callback_data": "orders:list:pending:offset=0"}],
+        [{"text": "Всі", "callback_data": "orders:list:all:offset=0"}],
+    ]
+
+
+def orders_list_buttons(kind: Literal["pending", "all"], offset: int, page_size: int) -> List[List[Button]]:
+    """Кнопки пагинации списка заказов"""
+    prev_offset = max(offset - page_size, 0)
+    next_offset = offset + page_size
+    return [
+        [
+            {"text": "⬅️", "callback_data": f"orders:list:{kind}:offset={prev_offset}"},
+            {"text": "➡️", "callback_data": f"orders:list:{kind}:offset={next_offset}"},
+        ]
+    ]
+
+
+def order_actions_buttons(order_id: int) -> List[List[Button]]:
+    """Кнопки действий с заказом"""
+    return [
+        [
+            {"text": "PDF", "callback_data": f"order:{order_id}:resend:pdf"},
+            {"text": "VCF", "callback_data": f"order:{order_id}:resend:vcf"},
+        ]
+    ]
+
+
+def order_card_buttons(order_id: int) -> List[List[Button]]:
+    """Кнопки в карточке заказа"""
+    buttons = order_actions_buttons(order_id)
+    buttons.append([{ "text": "Назад", "callback_data": "orders:list:pending:offset=0" }])
+    return buttons
+

--- a/app/services/tg_service.py
+++ b/app/services/tg_service.py
@@ -87,3 +87,47 @@ def send_text_with_buttons(message: str, buttons: list[list[dict]]):
         raise RuntimeError(f"Telegram API error: {resp.text}")
 
     return resp.json()
+
+
+def edit_message_text(chat_id: int | str, message_id: int, text: str,
+                      buttons: list[list[dict]] | None = None):
+    """Редактирование текста сообщения с опциональными кнопками."""
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is not set in .env")
+
+    url = f"https://api.telegram.org/bot{token}/editMessageText"
+    payload: dict[str, object] = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "parse_mode": "HTML",
+    }
+    if buttons:
+        payload["reply_markup"] = json.dumps({"inline_keyboard": buttons})
+
+    resp = requests.post(url, json=payload, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Telegram API error: {resp.text}")
+    return resp.json()
+
+
+def answer_callback_query(callback_query_id: str, text: str | None = None,
+                          show_alert: bool = False):
+    """Ответ на callback query"""
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN is not set in .env")
+
+    url = f"https://api.telegram.org/bot{token}/answerCallbackQuery"
+    payload: dict[str, object] = {"callback_query_id": callback_query_id}
+    if text:
+        payload["text"] = text
+    if show_alert:
+        payload["show_alert"] = True
+
+    resp = requests.post(url, data=payload, timeout=30)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Telegram API error: {resp.text}")
+    return resp.json()
+


### PR DESCRIPTION
## Summary
- add menu building helpers and callback routing
- extend Telegram service with message editing and callback answers
- handle Telegram callback queries via centralized router

## Testing
- `python -m py_compile app/services/menu_ui.py app/callbacks.py app/services/tg_service.py app/main.py`
- `pytest` *(fails: HTTPConnectionPool(host='localhost', port=8003) ... Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6292dd870832a862b15d59ac70a60