### PR TITLE
Add menu endpoint and main menu buttons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ from app.services.tg_service import (
     edit_message_text,
 )
 from app.services.status_ui import status_title, buttons_for_status
-from app.services.menu_ui import orders_list_buttons, order_card_buttons
+from app.services.menu_ui import orders_list_buttons, order_card_buttons, main_menu_buttons
 from app.callbacks import route_callback
 
 from app.bot.main import start_bot, stop_bot, get_bot
@@ -111,6 +111,14 @@ def _display_order_number(order: dict, fallback_id: int | str) -> str:
 
 @app.get("/health")
 def health():
+    return {"status": "ok"}
+
+
+@app.get("/menu")
+def show_menu():
+    """Отправить главное меню в Telegram"""
+    buttons = main_menu_buttons()
+    send_text_with_buttons("Главное меню", buttons)
     return {"status": "ok"}
 
 

--- a/app/services/menu_ui.py
+++ b/app/services/menu_ui.py
@@ -7,8 +7,8 @@ Button = dict
 def main_menu_buttons() -> List[List[Button]]:
     """Главное меню"""
     return [
-        [{"text": "Очікують", "callback_data": "orders:list:pending:offset=0"}],
-        [{"text": "Всі", "callback_data": "orders:list:all:offset=0"}],
+        [{"text": "📋 Необработанные", "callback_data": "orders:list:pending:offset=0"}],
+        [{"text": "📦 Все заказы", "callback_data": "orders:list:all:offset=0"}],
     ]
 
 


### PR DESCRIPTION
## Summary
- adjust main menu buttons to show pending and all orders with icons
- add `/menu` endpoint to send main menu message in Telegram

## Testing
- `pytest` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_68a6312c8ad4832a986e86ad49e90d32