### PR TITLE
Add menu command handler

### DIFF
--- a/app/bot/routers/commands.py
+++ b/app/bot/routers/commands.py
@@ -1,9 +1,17 @@
 from aiogram import Router
-from aiogram.filters import CommandStart
+from aiogram.filters import CommandStart, Command
 from aiogram.types import Message
+
+from app.services.menu_ui import main_menu_buttons
+from app.services.tg_service import send_text_with_buttons
 
 router = Router()
 
 @router.message(CommandStart())
 async def on_start(msg: Message):
     await msg.answer("Бот активен. Жмите кнопки под заказами 😉")
+
+
+@router.message(Command("menu"))
+async def on_menu(msg: Message):
+    send_text_with_buttons("Главное меню", main_menu_buttons())

--- a/tests/test_commands_menu.py
+++ b/tests/test_commands_menu.py
@@ -1,0 +1,16 @@
+import asyncio
+from unittest.mock import Mock, patch
+
+from app.bot.routers.commands import on_menu, main_menu_buttons
+
+
+def test_menu_command_sends_two_buttons():
+    with patch("app.bot.routers.commands.send_text_with_buttons") as send_mock:
+        asyncio.run(on_menu(Mock()))
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        assert args[0] == "Главное меню"
+        buttons = args[1]
+        assert buttons == main_menu_buttons()
+        assert len(buttons) == 2
+        assert all(len(row) == 1 for row in buttons)


### PR DESCRIPTION
## Summary
- add /menu command to show main menu buttons
- test menu command sends two buttons

## Testing
- `pytest -q` *(fails: HTTPConnectionPool(host='localhost', port=8003): Max retries exceeded)*
- `pytest tests/test_commands_menu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a637acfa1c832aab33a3efd7fd2239