### PR TITLE
Add orders list callback handler

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from aiogram import Router, F
 from aiogram.types import CallbackQuery
 
@@ -5,7 +7,9 @@ from app.db import get_session
 from app.models import Order, OrderStatus
 from app.services.status_ui import status_title
 from app.bot.texts import build_manager_message  # см. ниже "texts.py" (быстрая версия внутри этого файла)
-from app.services.tg_service import edit_message_text
+from app.bot.services.message_builder import get_status_emoji
+from app.services.menu_ui import orders_list_buttons
+from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()
 
@@ -43,3 +47,59 @@ async def on_order_status_click(cb: CallbackQuery):
     await cb.answer(f"Статус → {status_title(new_status)}")
     if chat_id and message_id:
         edit_message_text(chat_id, message_id, new_text)  # клавиши пересоберёт твой main при новых событиях
+
+
+def _parse_orders_list_data(data: str):
+    """Parse callback data for orders list.
+
+    Expected format: orders:list:<kind>:offset=<n>
+    Returns tuple(kind, offset) or (None, None) if invalid.
+    """
+    parts = data.split(":")
+    if len(parts) != 4 or parts[0] != "orders" or parts[1] != "list" or not parts[3].startswith("offset="):
+        return None, None
+    kind = parts[2]
+    try:
+        offset = int(parts[3].split("=", 1)[1])
+    except ValueError:
+        offset = 0
+    return kind, max(offset, 0)
+
+
+@router.callback_query(F.data.startswith("orders:list:"))
+async def on_orders_list_click(cb: CallbackQuery):
+    """Show list of orders with pagination."""
+    kind, offset = _parse_orders_list_data(cb.data)
+    if kind is None:
+        await cb.answer("Некоректні дані", show_alert=False)
+        return
+
+    PAGE_SIZE = 10
+    with get_session() as s:
+        query = s.query(Order)
+        if kind == "pending":
+            query = query.filter(Order.status == OrderStatus.NEW)
+        orders = query.order_by(Order.created_at.desc()).offset(offset).limit(PAGE_SIZE).all()
+
+    lines: list[str] = []
+    buttons: list[list[dict]] = []
+    for order in orders:
+        order_no = order.order_number or order.id
+        customer = f"{order.customer_first_name or ''} {order.customer_last_name or ''}".strip() or "Без імені"
+        emoji = get_status_emoji(order.status)
+        lines.append(f"• №{order_no} - {customer} {emoji}")
+        buttons.append([{ "text": f"№{order_no}", "callback_data": f"order:{order.id}:view" }])
+
+    # Pagination buttons
+    buttons.extend(orders_list_buttons(kind, offset, PAGE_SIZE))
+
+    text = f"Список замовлень ({kind})"
+    if lines:
+        text += "\n\n" + "\n".join(lines)
+    else:
+        text += "\n\nНемає замовлень"
+
+    result = send_text_with_buttons(text, buttons)
+    if asyncio.iscoroutine(result):
+        await result
+    await cb.answer()


### PR DESCRIPTION
## Summary
- support orders:list callback to display paginated orders with buttons
- show order summary lines with status emojis

## Testing
- `pytest -q` *(fails: ConnectionError to localhost:8003)*
- `pytest tests/test_commands_menu.py tests/test_phone_utils.py tests/test_vcf_service.py -q` *(fails: pretty_ua_phone format assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ea16a04832a81a03826d1ec6229