### PR TITLE
Handle order view callbacks and improve phone formatting

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -1,11 +1,15 @@
+import asyncio
+
 from aiogram import Router, F
 from aiogram.types import CallbackQuery
 
 from app.db import get_session
 from app.models import Order, OrderStatus
+from app.services.menu_ui import order_card_buttons
 from app.services.status_ui import status_title
+from app.bot.services.message_builder import build_order_message
 from app.bot.texts import build_manager_message  # см. ниже "texts.py" (быстрая версия внутри этого файла)
-from app.services.tg_service import edit_message_text
+from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()
 
@@ -16,7 +20,24 @@ def _parse_cbdata(data: str):
         return None, None
     return int(parts[1]), parts[3]
 
-@router.callback_query(F.data.startswith("order:"))
+@router.callback_query(F.data.regexp(r"^order:\d+:view$"))
+async def on_order_view_click(cb: CallbackQuery):
+    order_id = int(cb.data.split(":")[1])
+    with get_session() as s:
+        order = s.get(Order, order_id)
+        if not order:
+            await cb.answer("Замовлення не знайдено", show_alert=False)
+            return
+        message_text = build_order_message(order, detailed=True)
+        buttons = order_card_buttons(order.id)
+
+    result = send_text_with_buttons(message_text, buttons)
+    if asyncio.iscoroutine(result):
+        await result
+    await cb.answer()
+
+
+@router.callback_query(F.data.regexp(r"^order:\d+:set:"))
 async def on_order_status_click(cb: CallbackQuery):
     order_id, status_str = _parse_cbdata(cb.data)
     if not order_id or not status_str:

--- a/app/services/phone_utils.py
+++ b/app/services/phone_utils.py
@@ -58,7 +58,7 @@ def normalize_ua_phone(phone_raw: str | None) -> Optional[str]:
 
 def pretty_ua_phone(e164: str) -> str:
     """
-    Форматирует украинский номер для отображения: +380 XX XXX XX XX
+    Форматирует украинский номер для отображения: +38•XXX•XXX•XX•XX
     Если строка не E.164, вернёт её как есть.
     """
     if not e164:
@@ -68,5 +68,5 @@ def pretty_ua_phone(e164: str) -> str:
     if not (isinstance(e164, str) and e164.startswith("+380") and len(e164) == 13 and e164[1:].isdigit()):
         return e164
 
-    # Форматируем: +380 XX XXX XX XX
-    return f"{e164[:4]} {e164[4:6]} {e164[6:9]} {e164[9:11]} {e164[11:]}"
+    # Форматируем: +38•XXX•XXX•XX•XX
+    return f"{e164[:3]}•{e164[3:6]}•{e164[6:9]}•{e164[9:11]}•{e164[11:]}"

--- a/tests/test_callbacks_view.py
+++ b/tests/test_callbacks_view.py
@@ -1,0 +1,36 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch, Mock
+import os
+
+
+class DummySession:
+    def __init__(self, order):
+        self._order = order
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def get(self, model, _id):
+        return self._order
+
+
+def test_on_order_view_sends_detailed_message():
+    order = SimpleNamespace(id=123)
+    cb = Mock()
+    cb.data = "order:123:view"
+    cb.answer = AsyncMock()
+
+    with patch.dict(os.environ, {"DATABASE_URL": "sqlite://"}):
+        from app.bot.routers.callbacks import on_order_view_click
+
+        with patch("app.bot.routers.callbacks.get_session", return_value=DummySession(order)), \
+             patch("app.bot.routers.callbacks.build_order_message", return_value="DETAILS") as build_mock, \
+             patch("app.bot.routers.callbacks.order_card_buttons", return_value=[[{"text": "PDF"}]]) as buttons_mock, \
+             patch("app.bot.routers.callbacks.send_text_with_buttons", new_callable=AsyncMock) as send_mock:
+            asyncio.run(on_order_view_click(cb))
+
+            build_mock.assert_called_once_with(order, detailed=True)
+            buttons_mock.assert_called_once_with(order.id)
+            send_mock.assert_awaited_once_with("DETAILS", [[{"text": "PDF"}]])
+            cb.answer.assert_awaited()


### PR DESCRIPTION
## Summary
- add callback handler for `order:<id>:view` to show detailed order info
- format UA phone numbers with bullets and update docs
- test order view callback handler

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a63ea3bc8c832ab5fe1b775e38d05b