### PR TITLE
Handle view action for order callbacks

### DIFF
--- a/app/bot/handlers/callbacks.py
+++ b/app/bot/handlers/callbacks.py
@@ -180,7 +180,7 @@ async def handle_order_action(callback: CallbackQuery, state: FSMContext):
             await callback.message.edit_reply_markup(reply_markup=keyboard)
             await callback.answer("⏰ Оберіть час нагадування")
 
-        elif action == "show":
+        elif action in ("show", "view"):
             # Показываем детальную информацию
             details = build_order_message(order, detailed=True)
             await callback.answer(details, show_alert=True)


### PR DESCRIPTION
## Summary
- support "view" callback in order action handler by mapping it to the existing "show" flow

## Testing
- `pytest` *(fails: HTTPConnectionPool(host='localhost', port=8003)... Connection refused)*
- `pytest tests` *(fails: AssertionError: assert '+380 67 232 62 39' == '+38•067•232•62•39')*


------
https://chatgpt.com/codex/tasks/task_e_68a6423bac14832a9fd60a21a7bdd390