### PR TITLE
Register router callbacks for order actions

### DIFF
--- a/app/bot/main.py
+++ b/app/bot/main.py
@@ -8,8 +8,7 @@ from aiogram.enums import ParseMode
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
-from app.bot.handlers import callbacks
-from app.bot.routers import commands
+from app.bot.routers import commands, callbacks
 from app.db import get_session
 from app.models import Order, OrderStatus
 


### PR DESCRIPTION
## Summary
- import callbacks router from `app.bot.routers`
- include callbacks router in dispatcher registration so order callbacks are handled

## Testing
- `pytest -q` *(fails: ConnectionRefusedError to localhost:8003)*

------
https://chatgpt.com/codex/tasks/task_e_68a6423bdfa4832abb2c0aacd787c0bd