### PR TITLE
Consolidate menu imports in callbacks router

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -5,15 +5,10 @@ from aiogram.types import CallbackQuery
 
 from app.db import get_session
 from app.models import Order, OrderStatus
-from app.services.menu_ui import order_card_buttons
-from app.services.status_ui import status_title
-from app.bot.services.message_builder import build_order_message
+from app.bot.services.message_builder import build_order_message, get_status_emoji
 from app.bot.texts import build_manager_message  # см. ниже "texts.py" (быстрая версия внутри этого файла)
-
-from app.bot.services.message_builder import get_status_emoji
-from app.services.menu_ui import orders_list_buttons
-=======
-
+from app.services.menu_ui import order_card_buttons, orders_list_buttons
+from app.services.status_ui import status_title
 from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()


### PR DESCRIPTION
## Summary
- consolidate imports and remove stray line in callbacks router

## Testing
- `python -m py_compile app/bot/routers/callbacks.py`
- `python - <<'PY'
import os, importlib
os.environ['DATABASE_URL']='sqlite://'
importlib.import_module('app.bot.routers.callbacks')
print('import success')
PY`
- `pytest -q` *(fails: tests/test_phone_utils.py::test_pretty_format)*

------
https://chatgpt.com/codex/tasks/task_e_68a644225b98832aa9aa243d33a26ebd