### PR TITLE
Handle invalid order ID in callbacks

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -12,8 +12,6 @@ from app.bot.texts import build_manager_message  # см. ниже "texts.py" (б
 
 from app.bot.services.message_builder import get_status_emoji
 from app.services.menu_ui import orders_list_buttons
-=======
-
 from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()
@@ -23,7 +21,11 @@ def _parse_cbdata(data: str):
     parts = data.split(":")
     if len(parts) != 4 or parts[0] != "order" or parts[2] != "set":
         return None, None
-    return int(parts[1]), parts[3]
+    try:
+        order_id = int(parts[1])
+    except ValueError:
+        return None, None
+    return order_id, parts[3]
 
 @router.callback_query(F.data.regexp(r"^order:\d+:view$"))
 async def on_order_view_click(cb: CallbackQuery):
@@ -45,7 +47,7 @@ async def on_order_view_click(cb: CallbackQuery):
 @router.callback_query(F.data.regexp(r"^order:\d+:set:"))
 async def on_order_status_click(cb: CallbackQuery):
     order_id, status_str = _parse_cbdata(cb.data)
-    if not order_id or not status_str:
+    if order_id is None or status_str is None:
         await cb.answer("Некоректні дані", show_alert=False)
         return
 

--- a/app/services/phone_utils.py
+++ b/app/services/phone_utils.py
@@ -58,7 +58,7 @@ def normalize_ua_phone(phone_raw: str | None) -> Optional[str]:
 
 def pretty_ua_phone(e164: str) -> str:
     """
-    Форматирует украинский номер для отображения: +38•XXX•XXX•XX•XX
+    Форматирует украинский номер для отображения: +380 XX XXX XX XX
     Если строка не E.164, вернёт её как есть.
     """
     if not e164:
@@ -68,5 +68,5 @@ def pretty_ua_phone(e164: str) -> str:
     if not (isinstance(e164, str) and e164.startswith("+380") and len(e164) == 13 and e164[1:].isdigit()):
         return e164
 
-    # Форматируем: +38•XXX•XXX•XX•XX
-    return f"{e164[:3]}•{e164[3:6]}•{e164[6:9]}•{e164[9:11]}•{e164[11:]}"
+    # Форматируем: +380 XX XXX XX XX
+    return f"{e164[:4]} {e164[4:6]} {e164[6:9]} {e164[9:11]} {e164[11:]}"


### PR DESCRIPTION
## Summary
- Safely parse callback data and guard against malformed order IDs
- Keep order status handler resilient to None values
- Format Ukrainian phone numbers with standard spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64421e6f0832a91d9c9b8ef8549bd