### PR TITLE
Ensure SQLAlchemy session objects remain usable after commit

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -8,13 +8,16 @@ from app.models import Order, OrderStatus
 from app.services.menu_ui import order_card_buttons
 from app.services.status_ui import status_title
 from app.bot.services.message_builder import build_order_message
-from app.bot.texts import build_manager_message  # см. ниже "texts.py" (быстрая версия внутри этого файла)
+from app.bot.texts import (
+    build_manager_message,
+)  # см. ниже "texts.py" (быстрая версия внутри этого файла)
 
 from app.bot.services.message_builder import get_status_emoji
 from app.services.menu_ui import orders_list_buttons
 from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()
+
 
 def _parse_cbdata(data: str):
     # ожидаем: order:<id>:set:<STATUS>
@@ -26,6 +29,7 @@ def _parse_cbdata(data: str):
     except ValueError:
         return None, None
     return order_id, parts[3]
+
 
 @router.callback_query(F.data.regexp(r"^order:\d+:view$"))
 async def on_order_view_click(cb: CallbackQuery):
@@ -70,7 +74,9 @@ async def on_order_status_click(cb: CallbackQuery):
 
     await cb.answer(f"Статус → {status_title(new_status)}")
     if chat_id and message_id:
-        edit_message_text(chat_id, message_id, new_text)  # клавиши пересоберёт твой main при новых событиях
+        edit_message_text(
+            chat_id, message_id, new_text
+        )  # клавиши пересоберёт твой main при новых событиях
 
 
 def _parse_orders_list_data(data: str):
@@ -80,7 +86,12 @@ def _parse_orders_list_data(data: str):
     Returns tuple(kind, offset) or (None, None) if invalid.
     """
     parts = data.split(":")
-    if len(parts) != 4 or parts[0] != "orders" or parts[1] != "list" or not parts[3].startswith("offset="):
+    if (
+        len(parts) != 4
+        or parts[0] != "orders"
+        or parts[1] != "list"
+        or not parts[3].startswith("offset=")
+    ):
         return None, None
     kind = parts[2]
     try:
@@ -103,16 +114,26 @@ async def on_orders_list_click(cb: CallbackQuery):
         query = s.query(Order)
         if kind == "pending":
             query = query.filter(Order.status == OrderStatus.NEW)
-        orders = query.order_by(Order.created_at.desc()).offset(offset).limit(PAGE_SIZE).all()
+        orders = (
+            query.order_by(Order.created_at.desc())
+            .offset(offset)
+            .limit(PAGE_SIZE)
+            .all()
+        )
 
-    lines: list[str] = []
-    buttons: list[list[dict]] = []
-    for order in orders:
-        order_no = order.order_number or order.id
-        customer = f"{order.customer_first_name or ''} {order.customer_last_name or ''}".strip() or "Без імені"
-        emoji = get_status_emoji(order.status)
-        lines.append(f"• №{order_no} - {customer} {emoji}")
-        buttons.append([{ "text": f"№{order_no}", "callback_data": f"order:{order.id}:view" }])
+        lines: list[str] = []
+        buttons: list[list[dict]] = []
+        for order in orders:
+            order_no = order.order_number or order.id
+            customer = (
+                f"{order.customer_first_name or ''} {order.customer_last_name or ''}".strip()
+                or "Без імені"
+            )
+            emoji = get_status_emoji(order.status)
+            lines.append(f"• №{order_no} - {customer} {emoji}")
+            buttons.append(
+                [{"text": f"№{order_no}", "callback_data": f"order:{order.id}:view"}]
+            )
 
     # Pagination buttons
     buttons.extend(orders_list_buttons(kind, offset, PAGE_SIZE))

--- a/app/db.py
+++ b/app/db.py
@@ -16,10 +16,14 @@ if not DATABASE_URL:
 # sync engine, pool_pre_ping чтобы отлавливать отвалившиеся коннекты
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+SessionLocal = sessionmaker(
+    bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+)
+
 
 class Base(DeclarativeBase):
     pass
+
 
 @contextmanager
 def get_session():


### PR DESCRIPTION
## Summary
- Disable expiration on commit for SessionLocal
- Build order list UI while the DB session is open

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a649dcf08c832a8411202d7a846f14