### PR TITLE
Add main menu callback and buttons to orders UI

### DIFF
--- a/app/bot/routers/callbacks.py
+++ b/app/bot/routers/callbacks.py
@@ -5,7 +5,11 @@ from aiogram.types import CallbackQuery
 
 from app.db import get_session
 from app.models import Order, OrderStatus
-from app.services.menu_ui import order_card_buttons
+from app.services.menu_ui import (
+    order_card_buttons,
+    orders_list_buttons,
+    main_menu_buttons,
+)
 from app.services.status_ui import status_title
 from app.bot.services.message_builder import build_order_message
 from app.bot.texts import (
@@ -13,7 +17,6 @@ from app.bot.texts import (
 )  # см. ниже "texts.py" (быстрая версия внутри этого файла)
 
 from app.bot.services.message_builder import get_status_emoji
-from app.services.menu_ui import orders_list_buttons
 from app.services.tg_service import edit_message_text, send_text_with_buttons
 
 router = Router()
@@ -77,6 +80,15 @@ async def on_order_status_click(cb: CallbackQuery):
         edit_message_text(
             chat_id, message_id, new_text
         )  # клавиши пересоберёт твой main при новых событиях
+
+
+@router.callback_query(F.data == "menu:main")
+async def on_main_menu_click(cb: CallbackQuery):
+    """Return to the main menu."""
+    result = send_text_with_buttons("Главное меню", main_menu_buttons())
+    if asyncio.iscoroutine(result):
+        await result
+    await cb.answer()
 
 
 def _parse_orders_list_data(data: str):

--- a/app/services/menu_ui.py
+++ b/app/services/menu_ui.py
@@ -20,7 +20,8 @@ def orders_list_buttons(kind: Literal["pending", "all"], offset: int, page_size:
         [
             {"text": "⬅️", "callback_data": f"orders:list:{kind}:offset={prev_offset}"},
             {"text": "➡️", "callback_data": f"orders:list:{kind}:offset={next_offset}"},
-        ]
+        ],
+        [{"text": "🏠 Главное меню", "callback_data": "menu:main"}],
     ]
 
 
@@ -38,5 +39,6 @@ def order_card_buttons(order_id: int) -> List[List[Button]]:
     """Кнопки в карточке заказа"""
     buttons = order_actions_buttons(order_id)
     buttons.append([{ "text": "Назад", "callback_data": "orders:list:pending:offset=0" }])
+    buttons.append([{ "text": "🏠 Главное меню", "callback_data": "menu:main" }])
     return buttons
 

--- a/tests/test_orders_callbacks.py
+++ b/tests/test_orders_callbacks.py
@@ -77,14 +77,16 @@ def test_orders_list_buttons_structure():
         [
             {"text": "⬅️", "callback_data": "orders:list:pending:offset=0"},
             {"text": "➡️", "callback_data": "orders:list:pending:offset=10"},
-        ]
+        ],
+        [{"text": "🏠 Главное меню", "callback_data": "menu:main"}],
     ]
     buttons_all = orders_list_buttons("all", 0, page_size=5)
     assert buttons_all == [
         [
             {"text": "⬅️", "callback_data": "orders:list:all:offset=0"},
             {"text": "➡️", "callback_data": "orders:list:all:offset=5"},
-        ]
+        ],
+        [{"text": "🏠 Главное меню", "callback_data": "menu:main"}],
     ]
 
 
@@ -95,3 +97,4 @@ def test_order_card_buttons_structure():
         {"text": "VCF", "callback_data": "order:7:resend:vcf"},
     ]
     assert buttons[1] == [{"text": "Назад", "callback_data": "orders:list:pending:offset=0"}]
+    assert buttons[2] == [{"text": "🏠 Главное меню", "callback_data": "menu:main"}]


### PR DESCRIPTION
## Summary
- allow returning to main menu from order list and order card via new button
- handle `menu:main` callback to show main menu buttons
- adjust tests for updated button layouts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64c08410c832a875e44f925ed69d5