### PR TITLE
Throttle payment message dispatch

### DIFF
--- a/app/bot/routers/orders.py
+++ b/app/bot/routers/orders.py
@@ -28,6 +28,8 @@ from .shared import (
     clear_webhook_messages
 )
 
+PAYMENT_MESSAGE_DELAY = 1  # seconds to wait between payment messages
+
 router = Router()
 
 
@@ -490,6 +492,7 @@ async def on_payment_info(callback: CallbackQuery):
 
         for msg_text in copy_messages:
             await send_and_track(msg_text)
+            await asyncio.sleep(PAYMENT_MESSAGE_DELAY)
 
         elapsed_time = (asyncio.get_event_loop().time() - start_time) * 1000
         debug_print(f"💳 Payment info sent successfully in {elapsed_time:.0f}ms")


### PR DESCRIPTION
## Summary
- add configurable delay constant for payment messages
- throttle payment info messages to avoid spamming

## Testing
- `pytest` *(fails: DATABASE_URL is not set in .env file; ImportError: cannot import name 'telegram_webhook')*

------
https://chatgpt.com/codex/tasks/task_e_68ab4273f63c832a849300388429a7d5