### PR TITLE
Track webhook messages per chat

### DIFF
--- a/app/bot/routers/shared/__init__.py
+++ b/app/bot/routers/shared/__init__.py
@@ -27,7 +27,7 @@ from .state import (
     get_order_file_messages,
     clear_order_file_messages,
     clear_all_user_files,
-    # НОВЫЕ функции для webhook
+    # НОВЫЕ функции для webhook (учёт сообщений по чатам)
     add_webhook_message,
     get_webhook_messages,
     clear_webhook_messages,
@@ -88,3 +88,4 @@ __all__ = [
     'order_card_keyboard',
     'reminder_time_keyboard'
 ]
+

--- a/app/bot/routers/shared/state.py
+++ b/app/bot/routers/shared/state.py
@@ -11,8 +11,8 @@ user_order_files: Dict[int, Dict[int, Set[int]]] = {}  # user_id -> {order_id ->
 user_all_navigation_messages: Dict[int, Set[int]] = {}  # user_id -> {message_ids}
 
 # НОВОЕ: Трекинг WEBHOOK сообщений заказов
-# Теперь храним сообщения отдельно для каждого менеджера
-webhook_order_messages: Dict[int, Dict[int, Set[int]]] = {}  # order_id -> {user_id -> {message_ids}}
+# Теперь храним сообщения отдельно для каждого чата
+webhook_order_messages: Dict[int, Dict[int, Set[int]]] = {}  # order_id -> {chat_id -> {message_ids}}
 
 
 def get_navigation_message_id(user_id: int) -> int | None:
@@ -63,42 +63,70 @@ def remove_navigation_message(user_id: int, message_id: int) -> None:
 
 # НОВЫЕ функции для WEBHOOK сообщений
 
-def add_webhook_message(order_id: int, user_id: int, message_id: int) -> None:
-    """Добавить ID сообщения webhook заказа для конкретного менеджера"""
+def add_webhook_message(order_id: int, chat_id: int, message_id: int) -> None:
+    """Добавить ID сообщения webhook заказа для конкретного чата"""
     if order_id not in webhook_order_messages:
         webhook_order_messages[order_id] = {}
-    if user_id not in webhook_order_messages[order_id]:
-        webhook_order_messages[order_id][user_id] = set()
-    webhook_order_messages[order_id][user_id].add(message_id)
+    if chat_id not in webhook_order_messages[order_id]:
+        webhook_order_messages[order_id][chat_id] = set()
+    webhook_order_messages[order_id][chat_id].add(message_id)
 
 
-def get_webhook_messages(order_id: int) -> Dict[int, Set[int]]:
-    """Получить все webhook сообщения заказа, сгруппированные по менеджерам"""
+def get_webhook_messages(order_id: int, chat_id: int | None = None):
+    """Получить webhook сообщения заказа.
+
+    Если указан chat_id - возвращает множество ID сообщений для этого чата.
+    Если chat_id не указан - возвращает словарь {chat_id: {message_ids}}.
+    """
     if order_id not in webhook_order_messages:
-        return {}
-    return {uid: msgs.copy() for uid, msgs in webhook_order_messages[order_id].items()}
+        return set() if chat_id is not None else {}
+
+    if chat_id is None:
+        return {cid: msgs.copy() for cid, msgs in webhook_order_messages[order_id].items()}
+
+    return webhook_order_messages[order_id].get(chat_id, set()).copy()
 
 
-def clear_webhook_messages(order_id: int) -> None:
-    """Очистить все webhook сообщения заказа"""
-    if order_id in webhook_order_messages:
+def clear_webhook_messages(order_id: int, chat_id: int | None = None) -> None:
+    """Очистить webhook сообщения заказа.
+
+    Если указан chat_id - очищает только для этого чата.
+    Если chat_id не указан - очищает для всех чатов.
+    """
+    if order_id not in webhook_order_messages:
+        return
+
+    if chat_id is None:
         del webhook_order_messages[order_id]
+    else:
+        webhook_order_messages[order_id].pop(chat_id, None)
+        if not webhook_order_messages[order_id]:
+            del webhook_order_messages[order_id]
 
 
-def is_webhook_message(message_id: int) -> bool:
-    """Проверить, является ли сообщение webhook сообщением"""
-    for messages_by_user in webhook_order_messages.values():
-        for message_ids in messages_by_user.values():
-            if message_id in message_ids:
+def is_webhook_message(message_id: int, chat_id: int | None = None) -> bool:
+    """Проверить, является ли сообщение webhook сообщением."""
+    if chat_id is None:
+        for messages_by_chat in webhook_order_messages.values():
+            for message_ids in messages_by_chat.values():
+                if message_id in message_ids:
+                    return True
+    else:
+        for messages_by_chat in webhook_order_messages.values():
+            if message_id in messages_by_chat.get(chat_id, set()):
                 return True
     return False
 
 
-def get_order_by_webhook_message(message_id: int) -> int | None:
-    """Получить order_id по ID webhook сообщения"""
-    for order_id, messages_by_user in webhook_order_messages.items():
-        for message_ids in messages_by_user.values():
-            if message_id in message_ids:
+def get_order_by_webhook_message(message_id: int, chat_id: int | None = None) -> int | None:
+    """Получить order_id по ID webhook сообщения."""
+    for order_id, messages_by_chat in webhook_order_messages.items():
+        if chat_id is None:
+            for message_ids in messages_by_chat.values():
+                if message_id in message_ids:
+                    return order_id
+        else:
+            if message_id in messages_by_chat.get(chat_id, set()):
                 return order_id
     return None
 

--- a/app/bot/routers/shared/utils.py
+++ b/app/bot/routers/shared/utils.py
@@ -67,9 +67,6 @@ def check_permission(user_id: int) -> bool:
 
     except Exception as e:
         debug_print(f"🔇 SILENT BLOCK: Error checking permissions for user {user_id}: {e}", "ERROR")
-        return False
-
-
 def format_phone_compact(e164: str) -> str:
     """Форматирует телефон компактно без пробелов"""
     if not e164:


### PR DESCRIPTION
## Summary
- Track webhook order messages per chat instead of per user
- Allow retrieving and clearing webhook messages by chat or across all chats
- Document chat-based webhook helpers in shared module

## Testing
- `pytest -q` *(fails: DATABASE_URL is not set, telegram_webhook import error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab528befe4832ab5ea090151623a3e