### PR TITLE
Use divider constant in message builder

### DIFF
--- a/app/bot/services/message_builder.py
+++ b/app/bot/services/message_builder.py
@@ -1,6 +1,8 @@
 # app/bot/services/message_builder.py
 from app.models import Order, OrderStatus
 
+DIVIDER = '—' * 20
+
 
 def get_status_emoji(status: OrderStatus) -> str:
     """Получить эмодзи для статуса"""
@@ -45,16 +47,18 @@ def build_order_message(order: Order, detailed: bool = False) -> str:
     phone = format_phone_compact(order.customer_phone_e164)
 
     # Основное сообщение
-    message = f"""📦 <b>Замовлення #{order_no}</b> • {status_emoji} {status_text}
-━━━━━━━━━━━━━━━━━━━━━━
-👤 {customer_name}
-📱 {phone}"""
+    message = (
+        f"""📦 <b>Замовлення #{order_no}</b> • {status_emoji} {status_text}\n"
+        f"{DIVIDER}\n"
+        f"👤 {customer_name}\n"
+        f"📱 {phone}"""
+    )
 
     # Детальная информация (если запрошено и есть данные)
     if detailed and order.raw_json:
         data = order.raw_json
 
-        message += "\n━━━━━━━━━━━━━━━━━━━━━━"
+        message += f"\n{DIVIDER}"
 
         # Товары
         items = data.get("line_items", [])
@@ -88,7 +92,7 @@ def build_order_message(order: Order, detailed: bool = False) -> str:
 
     # Дополнительная информация (если есть)
     if order.comment or order.reminder_at or order.processed_by_username:
-        message += "\n━━━━━━━━━━━━━━━━━━━━━━"
+        message += f"\n{DIVIDER}"
 
         if order.comment:
             message += f"\n💬 <i>Коментар: {order.comment}</i>"

--- a/app/bot/services/message_builder.py
+++ b/app/bot/services/message_builder.py
@@ -1,7 +1,9 @@
 # app/bot/services/message_builder.py
 from app.models import Order, OrderStatus
 
-DIVIDER = '—' * 20
+# Using box-drawing characters keeps the divider a consistent width across
+# different devices and avoids wrapping to a second line.
+DIVIDER = '━' * 22
 
 
 def get_status_emoji(status: OrderStatus) -> str:


### PR DESCRIPTION
## Summary
- centralize the order message divider into a `DIVIDER` constant
- replace hardcoded separators with the constant for clarity

## Testing
- `pytest` *(fails: DATABASE_URL is not set in .env file; ImportError: cannot import name 'telegram_webhook')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5590bb14832a94eb1bc12ca53b32