### PR TITLE
chore: add trailing newline to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ reportlab>=4.2.0
 jinja2>=3.1.4
 pytz>=2024.1
 apscheduler>=3.10.4
+


### PR DESCRIPTION
## Summary
- ensure requirements.txt ends with a blank line

## Testing
- `pytest` *(fails: DATABASE_URL is not set; ImportError: cannot import name 'telegram_webhook')*

------
https://chatgpt.com/codex/tasks/task_e_68ab580a5418832ab188d6b071f849c0