### PR TITLE
chore: document env vars and parameterize compose db creds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Database connection string for the application
+DATABASE_URL=postgresql+psycopg://user:pass@db:5432/shopify_orders
+
+# Credentials for the Postgres container (used by docker-compose)
+POSTGRES_USER=user
+POSTGRES_PASSWORD=pass
+POSTGRES_DB=shopify_orders
+
+# Shopify configuration
+SHOPIFY_STORE_DOMAIN=example.myshopify.com
+SHOPIFY_API_VERSION=2025-07
+SHOPIFY_ADMIN_ACCESS_TOKEN=shpat_your_access_token
+SHOPIFY_WEBHOOK_SECRET=changeme
+
+# Telegram bot configuration
+TELEGRAM_BOT_TOKEN=000000:TEST
+TELEGRAM_TARGET_CHAT_ID=123456789
+TELEGRAM_ALLOWED_USER_IDS=123456789,987654321
+TELEGRAM_WEBHOOK_SECRET_TOKEN=changeme
+TELEGRAM_MODE=polling
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Shopify Order Notifier
+
+## Configuration
+
+1. Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
+   ```
+2. Fill in the variables inside `.env` with your own tokens and database credentials.
+
+`docker-compose.yml` reads these variables and spins up a local Postgres instance for development. The defaults in `.env.example` are placeholders and should be changed for real deployments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,26 @@ services:
     image: postgres:16
     container_name: shopify_orders_db
     environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: pass
-      POSTGRES_DB: shopify_orders
+      POSTGRES_USER: ${POSTGRES_USER:-user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pass}
+      POSTGRES_DB: ${POSTGRES_DB:-shopify_orders}
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "user"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-user}"]
       interval: 5s
       timeout: 3s
       retries: 10
+  app:
+    build: .
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- expand `.env.example` with Shopify, Telegram, and Postgres variables
- use `.env` variables for Postgres credentials in `docker-compose.yml`
- clarify configuration instructions in README

## Testing
- `pytest` *(fails: ImportError: cannot import name 'on_menu' from 'app.bot.routers.commands')*

------
https://chatgpt.com/codex/tasks/task_e_68ab57c06098832a910c39fbb02d96f5