### PR TITLE
Add Telegram webhook endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -139,11 +139,13 @@ def root():
         "status": "running",
         "endpoints": {
             "health": "/health",
-            "webhook": "/webhooks/shopify/orders"
+            "webhook": "/webhooks/shopify/orders",
+            "telegram": "/telegram/webhook"
         }
     }
 
 
+@app.post("/telegram/webhook")
 async def telegram_webhook(request: Request):
     """Minimal handler for Telegram callbacks used in tests."""
     data = await request.json()


### PR DESCRIPTION
## Summary
- expose `/telegram/webhook` via FastAPI and document it in root endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `pip install aiosqlite` *(fails: Could not find a version that satisfies the requirement aiosqlite; Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab78511ed4832ab73c6b814ca2bbdf